### PR TITLE
Add time-based greeting endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/nl/cge/GreetingRequest.java
+++ b/src/main/java/nl/cge/GreetingRequest.java
@@ -1,0 +1,3 @@
+package nl.cge;
+
+public record GreetingRequest(String name) {}

--- a/src/main/java/nl/cge/GreetingResource.java
+++ b/src/main/java/nl/cge/GreetingResource.java
@@ -1,9 +1,13 @@
 package nl.cge;
 
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.core.MediaType;
+
+import java.time.LocalTime;
 
 @Path("/hello")
 public class GreetingResource {
@@ -12,5 +16,25 @@ public class GreetingResource {
     @Produces(MediaType.TEXT_PLAIN)
     public String hello() {
         return "Hello from Quarkus REST";
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public GreetingResponse greet(GreetingRequest request) {
+        String partOfDay = calculatePartOfDay();
+        String message = "Hello " + request.name() + ", een hele goede " + partOfDay;
+        return new GreetingResponse(message);
+    }
+
+    private String calculatePartOfDay() {
+        int hour = LocalTime.now().getHour();
+        if (hour < 12) {
+            return "ochtend";
+        }
+        if (hour < 18) {
+            return "middag";
+        }
+        return "avond";
     }
 }

--- a/src/main/java/nl/cge/GreetingResponse.java
+++ b/src/main/java/nl/cge/GreetingResponse.java
@@ -1,0 +1,3 @@
+package nl.cge;
+
+public record GreetingResponse(String message) {}

--- a/src/test/java/nl/cge/GreetingResourceTest.java
+++ b/src/test/java/nl/cge/GreetingResourceTest.java
@@ -3,6 +3,8 @@ package nl.cge;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalTime;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
@@ -17,4 +19,27 @@ class GreetingResourceTest {
              .body(is("Hello from Quarkus REST"));
     }
 
+    @Test
+    void testGreetingPost() {
+        String partOfDay = calculatePartOfDay();
+
+        given()
+            .contentType("application/json")
+            .body("{\"name\":\"Codex\"}")
+            .when().post("/hello")
+            .then()
+                .statusCode(200)
+                .body("message", is("Hello Codex, een hele goede " + partOfDay));
+    }
+
+    private String calculatePartOfDay() {
+        int hour = LocalTime.now().getHour();
+        if (hour < 12) {
+            return "ochtend";
+        }
+        if (hour < 18) {
+            return "middag";
+        }
+        return "avond";
+    }
 }


### PR DESCRIPTION
## Summary
- introduce `GreetingRequest` and `GreetingResponse` records
- expand `GreetingResource` with new POST endpoint returning JSON
- create tests for the time-based greeting

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684c72d688188331ab3f62fab0b81e98