### PR TITLE
Add validation on name input

### DIFF
--- a/src/main/java/nl/cge/GreetingPageResource.java
+++ b/src/main/java/nl/cge/GreetingPageResource.java
@@ -23,14 +23,18 @@ public class GreetingPageResource {
     @GET
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance getPage() {
-        return greeting.data("message", null);
+        return greeting.data("message", null).data("error", null);
     }
 
     @POST
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance postName(@FormParam("name") String name) {
-        GreetingResponse response = greetingService.greet(name);
-        return greeting.data("message", response.message());
+        try {
+            GreetingResponse response = greetingService.greet(name);
+            return greeting.data("message", response.message()).data("error", null);
+        } catch (IllegalArgumentException e) {
+            return greeting.data("message", null).data("error", e.getMessage());
+        }
     }
 }

--- a/src/main/java/nl/cge/GreetingService.java
+++ b/src/main/java/nl/cge/GreetingService.java
@@ -7,6 +7,11 @@ import java.time.LocalTime;
 public class GreetingService {
 
     public GreetingResponse greet(String name) {
+        if (name == null || !name.matches("[A-Za-z\\- ]{2,}")) {
+            throw new IllegalArgumentException(
+                "Name must contain at least 2 characters and may only consist of letters, spaces and '-'"
+            );
+        }
         String partOfDay = calculatePartOfDay();
         String message = "Hello " + name + ", een hele goede " + partOfDay;
         return new GreetingResponse(message);

--- a/src/main/resources/templates/greeting.html
+++ b/src/main/resources/templates/greeting.html
@@ -55,7 +55,7 @@
 <body>
 <form method="post" action="/greeting">
     <label for="name">Name:</label>
-    <input id="name" name="name" type="text">
+    <input id="name" name="name" type="text" pattern="[A-Za-z\\- ]{2,}" title="Minimaal 2 karakters. Alleen letters, spaties en '-' toegestaan" required>
     <button type="submit">Greet</button>
 </form>
 {#if message}

--- a/src/main/resources/templates/greeting.html
+++ b/src/main/resources/templates/greeting.html
@@ -55,7 +55,7 @@
 <body>
 <form method="post" action="/greeting">
     <label for="name">Name:</label>
-    <input id="name" name="name" type="text" pattern="[A-Za-z\\- ]{2,}" title="Minimaal 2 karakters. Alleen letters, spaties en '-' toegestaan" required>
+    <input id="name" name="name" type="text" pattern="[A-Za-z\\- ]&#123;2,&#125;" title="Minimaal 2 karakters. Alleen letters, spaties en '-' toegestaan" required>
     <button type="submit">Greet</button>
 </form>
 {#if message}

--- a/src/main/resources/templates/greeting.html
+++ b/src/main/resources/templates/greeting.html
@@ -50,6 +50,12 @@
             font-weight: bold;
             color: #333;
         }
+
+        #error {
+            margin-top: 1rem;
+            color: #cc0000;
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>
@@ -60,6 +66,9 @@
 </form>
 {#if message}
     <p id="result">{message}</p>
+{/if}
+{#if error}
+    <p id="error">{error}</p>
 {/if}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- validate name input in `GreetingService`
- require a minimum of 2 characters in the greeting page and only allow letters, spaces and '-'

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684c8a06ad208331918c7f9544f6aab6