### PR TITLE
Add tasks page

### DIFF
--- a/WIKI.md
+++ b/WIKI.md
@@ -5,11 +5,15 @@ Dit project is een eenvoudige Quarkus-applicatie die server-side templating demo
 ## Endpoints
 
 - `GET /greeting` levert een HTML-pagina met een formulier om een naam in te voeren. De pagina toont de groet of een foutmelding.
+- `GET /tasks` toont een pagina waarop taken kunnen worden toegevoegd en weergegeven.
+- `POST /tasks` voegt een taak toe met naam, omschrijving en einddatum.
 
 ## Kernonderdelen
 
 - `GreetingService` valideert de opgegeven naam, bepaalt het deel van de dag en stelt de groet samen.
 - `GreetingPageResource` rendert de `/greeting` HTML-pagina via een Qute-template.
+- `TaskService` beheert een eenvoudige in-memory lijst van taken.
+- `TaskPageResource` verzorgt het tonen en toevoegen van taken via `/tasks`.
 - `GreetingResponse` is een eenvoudig record om data uit te wisselen.
 
 De service berekent of het ochtend, middag of avond is op basis van de servertijd en verwerkt dat in de groet.

--- a/WIKI.md
+++ b/WIKI.md
@@ -12,7 +12,7 @@ Dit project is een eenvoudige Quarkus-applicatie die server-side templating demo
 
 - `GreetingService` valideert de opgegeven naam, bepaalt het deel van de dag en stelt de groet samen.
 - `GreetingPageResource` rendert de `/greeting` HTML-pagina via een Qute-template.
-- `TaskService` beheert een eenvoudige in-memory lijst van taken.
+- `TaskService` slaat taken op in een in-memory H2 database.
 - `TaskPageResource` verzorgt het tonen en toevoegen van taken via `/tasks`.
 - `GreetingResponse` is een eenvoudig record om data uit te wisselen.
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,14 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/nl/cge/greeting/GreetingPageResource.java
+++ b/src/main/java/nl/cge/greeting/GreetingPageResource.java
@@ -1,4 +1,4 @@
-package nl.cge;
+package nl.cge.greeting;
 
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;

--- a/src/main/java/nl/cge/greeting/GreetingResponse.java
+++ b/src/main/java/nl/cge/greeting/GreetingResponse.java
@@ -1,3 +1,3 @@
-package nl.cge;
+package nl.cge.greeting;
 
 public record GreetingResponse(String message) {}

--- a/src/main/java/nl/cge/greeting/GreetingService.java
+++ b/src/main/java/nl/cge/greeting/GreetingService.java
@@ -1,4 +1,4 @@
-package nl.cge;
+package nl.cge.greeting;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import java.time.LocalTime;

--- a/src/main/java/nl/cge/tasks/Task.java
+++ b/src/main/java/nl/cge/tasks/Task.java
@@ -1,0 +1,5 @@
+package nl.cge.tasks;
+
+import java.time.LocalDate;
+
+public record Task(String name, String description, LocalDate endDate) {}

--- a/src/main/java/nl/cge/tasks/Task.java
+++ b/src/main/java/nl/cge/tasks/Task.java
@@ -1,5 +1,27 @@
 package nl.cge.tasks;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import java.time.LocalDate;
 
-public record Task(String name, String description, LocalDate endDate) {}
+@Entity
+public class Task {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    public String name;
+    public String description;
+    public LocalDate endDate;
+
+    public Task() {
+    }
+
+    public Task(String name, String description, LocalDate endDate) {
+        this.name = name;
+        this.description = description;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/nl/cge/tasks/TaskPageResource.java
+++ b/src/main/java/nl/cge/tasks/TaskPageResource.java
@@ -1,0 +1,35 @@
+package nl.cge.tasks;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+import java.time.LocalDate;
+
+@Path("/tasks")
+public class TaskPageResource {
+
+    @Inject
+    Template tasks;
+
+    @Inject
+    TaskService taskService;
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance getPage() {
+        return tasks.data("tasks", taskService.listTasks());
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance addTask(@FormParam("name") String name,
+                                   @FormParam("description") String description,
+                                   @FormParam("endDate") String endDate) {
+        taskService.addTask(name, description, LocalDate.parse(endDate));
+        return tasks.data("tasks", taskService.listTasks());
+    }
+}

--- a/src/main/java/nl/cge/tasks/TaskService.java
+++ b/src/main/java/nl/cge/tasks/TaskService.java
@@ -1,21 +1,24 @@
 package nl.cge.tasks;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @ApplicationScoped
 public class TaskService {
-    private final List<Task> tasks = new ArrayList<>();
+    @Inject
+    EntityManager em;
 
-    public synchronized void addTask(String name, String description, LocalDate endDate) {
-        tasks.add(new Task(name, description, endDate));
+    @Transactional
+    public void addTask(String name, String description, LocalDate endDate) {
+        em.persist(new Task(name, description, endDate));
     }
 
     public List<Task> listTasks() {
-        return Collections.unmodifiableList(tasks);
+        return em.createQuery("from Task", Task.class).getResultList();
     }
 }

--- a/src/main/java/nl/cge/tasks/TaskService.java
+++ b/src/main/java/nl/cge/tasks/TaskService.java
@@ -1,0 +1,21 @@
+package nl.cge.tasks;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@ApplicationScoped
+public class TaskService {
+    private final List<Task> tasks = new ArrayList<>();
+
+    public synchronized void addTask(String name, String description, LocalDate endDate) {
+        tasks.add(new Task(name, description, endDate));
+    }
+
+    public List<Task> listTasks() {
+        return Collections.unmodifiableList(tasks);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+quarkus.hibernate-orm.database.generation=drop-and-create

--- a/src/main/resources/templates/greeting.html
+++ b/src/main/resources/templates/greeting.html
@@ -73,7 +73,7 @@
 </div>
 <form method="post" action="/greeting">
     <label for="name">Name:</label>
-    <input id="name" name="name" type="text" pattern="[A-Za-z\\- ]{2,}" title="Minimaal 2 karakters. Alleen letters, spaties en '-' toegestaan" required>
+    <input id="name" name="name" type="text" pattern="[A-Za-z\\- ]&#123;2,&#125;" title="Minimaal 2 karakters. Alleen letters, spaties en '-' toegestaan" required>
     <button type="submit">Greet</button>
 </form>
 {#if message}

--- a/src/main/resources/templates/tasks.html
+++ b/src/main/resources/templates/tasks.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Greeting</title>
+    <title>Taken</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -54,15 +54,13 @@
             border-radius: 4px;
             cursor: pointer;
         }
-        #result {
+        table {
+            border-collapse: collapse;
             margin-top: 1rem;
-            font-weight: bold;
-            color: #333;
         }
-        #error {
-            margin-top: 1rem;
-            color: #cc0000;
-            font-weight: bold;
+        th, td {
+            border: 1px solid #ccc;
+            padding: 0.5rem 1rem;
         }
     </style>
 </head>
@@ -71,16 +69,30 @@
     <a href="/greeting">Greeting</a>
     <a href="/tasks">Taken</a>
 </div>
-<form method="post" action="/greeting">
-    <label for="name">Name:</label>
-    <input id="name" name="name" type="text" pattern="[A-Za-z\\- ]{2,}" title="Minimaal 2 karakters. Alleen letters, spaties en '-' toegestaan" required>
-    <button type="submit">Greet</button>
+<form method="post" action="/tasks">
+    <label for="name">Naam:</label>
+    <input id="name" name="name" type="text" required>
+    <label for="description">Omschrijving:</label>
+    <input id="description" name="description" type="text" required>
+    <label for="endDate">Einddatum:</label>
+    <input id="endDate" name="endDate" type="date" required>
+    <button type="submit">Voeg taak toe</button>
 </form>
-{#if message}
-    <p id="result">{message}</p>
-{/if}
-{#if error}
-    <p id="error">{error}</p>
+{#if tasks.size > 0}
+<table id="task-list">
+    <thead>
+        <tr><th>Naam</th><th>Omschrijving</th><th>Einddatum</th></tr>
+    </thead>
+    <tbody>
+    {#for task in tasks}
+        <tr>
+            <td>{task.name}</td>
+            <td>{task.description}</td>
+            <td>{task.endDate}</td>
+        </tr>
+    {/for}
+    </tbody>
+</table>
 {/if}
 </body>
 </html>

--- a/src/test/java/nl/cge/greeting/GreetingPageResourceTest.java
+++ b/src/test/java/nl/cge/greeting/GreetingPageResourceTest.java
@@ -1,4 +1,4 @@
-package nl.cge;
+package nl.cge.greeting;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/nl/cge/tasks/TaskPageResourceTest.java
+++ b/src/test/java/nl/cge/tasks/TaskPageResourceTest.java
@@ -1,0 +1,35 @@
+package nl.cge.tasks;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+@QuarkusTest
+class TaskPageResourceTest {
+
+    @Test
+    void testGetPage() {
+        given()
+          .when().get("/tasks")
+          .then()
+             .statusCode(200)
+             .body(containsString("<form"));
+    }
+
+    @Test
+    void testPostTask() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("name", "Test")
+            .formParam("description", "Beschrijving")
+            .formParam("endDate", "2030-01-01")
+            .when().post("/tasks")
+            .then()
+                .statusCode(200)
+                .body(containsString("Test"))
+                .body(containsString("Beschrijving"))
+                .body(containsString("2030-01-01"));
+    }
+}


### PR DESCRIPTION
## Summary
- add new tasks page with Task/TaskService to store tasks in memory
- show navigation tabs on greeting and tasks pages
- document new endpoints in the wiki
- tests for TaskPageResource

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6850368927308331b743dcc41b3791b4